### PR TITLE
chore: add changelog for v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# v3.0.0-alpha
+
+## Features
+
+- Start project: add CI config, Dockerfiles, License
+
+## Chores
+
+- Use published image for docker-compose [#4](https://github.com/reactioncommerce/reaction-identity/pull/4)


### PR DESCRIPTION
We want to add this repo to our v3.0.0 release, however:

- this is a very new repo, and there is only one PR [here](https://github.com/reactioncommerce/reaction-identity/pulls?q=is%3Apr+is%3Aclosed) and these commits:
```
✗ git log --pretty=oneline
142c5dcaf771fdb59680e97f370eaca1ca4e3303 chore: use published image for docker-compose
cfd6d4c5e2c502e139f5ed3330e1d3af3ba1e278 chore: fix crashing of Docker image
0ee488b355eaa9303156be8be771045b6ab7099f chore: improve Dockerfile
56e7248fe844fc1dd3e282974343547ddafc8b8c chore: docker ignore for faster docker build
e01f84700e4a4cd2447ffc75a67f20270e046ce3 feat: add logging after server starts
d2d924a14f65cdaea0ed626b7f56946ac5022073 chore: fix lint
dc0250f4d4d52103e8c7c50eebfd7e14a934177b chore: correct ports in docker-compose
a31d9fa8c49527a7de1cb6dc87655ca4268d23cb chore: add missing docker compose command
d05a7d9184d424152e21bbd4043b2a9164a3215e chore: update eslint config rules
d9c675296037856d702cbdd8dbae805053bad997 docs: add readme
fd2b04fa2757396187d6dd3ff2174456f54e2211 chore: add CI config
c719d18cf5fd3be8692f549e9f94e74e2c98b43c chore: add Docker files
744b8ffc84618f6eada9d17fdbd1e76e994fde76 chore: add license
3491aebc865dca9d2361b67bd76eacc9e1605ddf chore: update package.json
3d79b57e06dc6dc9722e4e317ea32adc98b4487c chore: add project hooks
e5116ad3bafb2993b1fd97c5b500b47edad2cd7d feat: updates for Hydra 1.0.8
a97c1aa3fa3087eefba7e9f4718d3a68aeeb62cf feat: initial work on separated IDP
```

Not sure whether we should just add the one PR link, or include the commits.
Ross, please advise.