### PR TITLE
feat: add non-English translations

### DIFF
--- a/server/i18n/ar.json
+++ b/server/i18n/ar.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "غير كلمة السر",
+  "createAccount": "افتح حساب جديد",
+  "currentPassword": "كلمة السر الحالية",
+  "emailAddress": "البريد الالكترونى",
+  "error": "خطأ",
+  "forgotPassword": "نسيت كلمة السر؟",
+  "newPassword": "كلمة السر الجديدة",
+  "password": "كلمة السر",
+  "passwordChanged": "تم تغيير كلمة السر",
+  "passwordResetSend": "تم ارسال البريد الإلكتروني مع رابط لإعادة تعيين كلمة المرور.",
+  "resetYourPassword": "اعادة تعيين كلمة السر",
+  "setPassword": "تعيين كلمة السر",
+  "signIn": "تسجيل الدخول",
+  "signUp": "افتح حساب جديد",
+  "signUpButton": "تسجيل ",
+  "updateYourPassword": "جدد كلمة السر"
+}

--- a/server/i18n/bg.json
+++ b/server/i18n/bg.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Смени парола",
+  "createAccount": "Създай акаунт",
+  "currentPassword": "Сегашна парола",
+  "emailAddress": "имейл адрес",
+  "error": "Грешка",
+  "forgotPassword": "забравих си паролата",
+  "newPassword": "Нова парола",
+  "password": "Парола",
+  "passwordChanged": "Паролата е променена",
+  "passwordResetSend": "Имейл с линк за нулиране на паролата е изпратен.",
+  "resetYourPassword": "Променете паролата си",
+  "setPassword": "избери парола",
+  "signIn": "Впиши се",
+  "signUp": "Регистрация",
+  "signUpButton": "Регистрирам",
+  "updateYourPassword": "Обновете паролата си"
+}

--- a/server/i18n/cs.json
+++ b/server/i18n/cs.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Změnte heslo",
+  "createAccount": "Vytvořit účet",
+  "currentPassword": "Současné heslo",
+  "emailAddress": "Emailová adresa",
+  "error": "Chyba",
+  "forgotPassword": "Zapomenuté heslo?",
+  "newPassword": "Nové heslo",
+  "password": "Heslo",
+  "passwordChanged": "Heslo změněno",
+  "passwordResetSend": "byl odeslán e-mail s odkazem pro resetování hesla.",
+  "resetYourPassword": "Resetovat heslo",
+  "setPassword": "Nastavit heslo",
+  "signIn": "Přihlásit se",
+  "signUp": "Registrovat",
+  "signUpButton": "Registrovat",
+  "updateYourPassword": "Aktualizujte si své heslo"
+}

--- a/server/i18n/de.json
+++ b/server/i18n/de.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Passwort ändern",
+  "createAccount": "Konto anlegen",
+  "currentPassword": "Aktuelles Passwort",
+  "emailAddress": "E-Mail-Adresse",
+  "error": "Fehler",
+  "forgotPassword": "Passwort vergessen?",
+  "newPassword": "Neues Passwort",
+  "password": "Passwort",
+  "passwordChanged": "Das Passwort wurde geändert",
+  "passwordResetSend": "Eine E-Mail mit Link zum Zurücksetzen des Passworts wurde gesendet. ",
+  "resetYourPassword": "Passwort zurücksetzen",
+  "setPassword": "Passwort neu setzen",
+  "signIn": "Anmelden",
+  "signUp": "Registrieren",
+  "signUpButton": "Registrieren",
+  "updateYourPassword": "Passwort aktualisieren"
+}

--- a/server/i18n/el.json
+++ b/server/i18n/el.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Αλλαγή κωδικού",
+  "createAccount": "Δημιουργία λογαριασμού",
+  "currentPassword": "Τρέχον κωδικός",
+  "emailAddress": "Διεύθυνση Email",
+  "error": "Σφάλμα",
+  "forgotPassword": "Επαναφορά κωδικού",
+  "newPassword": "Νέος κωδικός",
+  "password": "Κωδικός",
+  "passwordChanged": "Ο κωδικός άλλαξε επιτυχώς",
+  "passwordResetSend": "E-mail με σύνδεσμο επαναφοράς κωδικού πρόσβασης έχει αποσταλεί.",
+  "resetYourPassword": "Επαναφορά κωδικού",
+  "setPassword": "Διάλεξε κωδικό",
+  "signIn": "Σύνδεση",
+  "signUp": "Εγγραφή",
+  "signUpButton": "Κανω ΕΓΓΡΑΦΗ",
+  "updateYourPassword": "Ενημέρωση κωδικού"
+}

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3,7 +3,7 @@
   "changePassword": "Change password",
   "createAccount": "Create an Account",
   "currentPassword": "Current password",
-  "emailAddress": "Email",
+  "emailAddress": "Email address",
   "error": "Error",
   "forgotPassword": "Reset password",
   "newPassword": "New password",

--- a/server/i18n/es.json
+++ b/server/i18n/es.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Cambiar contraseña",
+  "createAccount": "Crear una cuenta",
+  "currentPassword": "Contraseña actual",
+  "emailAddress": "Dirección de correo electrónico",
+  "error": "Error",
+  "forgotPassword": "Restablecer contraseña",
+  "newPassword": "Nueva contraseña",
+  "password": "Contraseña",
+  "passwordChanged": "La contraseña ha cambiado",
+  "passwordResetSend": "Se ha enviado un correo electrónico con enlace para restablecer la contraseña.",
+  "resetYourPassword": "Restablecer tu contraseña",
+  "setPassword": "Establecer contraseña",
+  "signIn": "Iniciar sesión",
+  "signUp": "Registrar",
+  "signUpButton": "Registrar",
+  "updateYourPassword": "Actualiza tu contraseña"
+}

--- a/server/i18n/fr.json
+++ b/server/i18n/fr.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Modifier le mot de passe",
+  "createAccount": "Créer un compte",
+  "currentPassword": "Mot de passe actuel",
+  "emailAddress": "Adresse e-mail",
+  "error": "Erreur",
+  "forgotPassword": "Mot de passe oublié",
+  "newPassword": "Nouveau mot de passe",
+  "password": "Mot de passe",
+  "passwordChanged": "Mot de passe modifié",
+  "passwordResetSend": "Un e-mail contenant un lien de réinitialisation du mot de passe a été envoyé.",
+  "resetYourPassword": "Réinitialisez votre mot de passe",
+  "setPassword": "Définir le mot de passe",
+  "signIn": "Connexion",
+  "signUp": "Créer un compte",
+  "signUpButton": "Créer un compte",
+  "updateYourPassword": "Mettre à jour votre mot de passe"
+}

--- a/server/i18n/he.json
+++ b/server/i18n/he.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "שינוי סיסמא",
+  "createAccount": "הוספת חשבון",
+  "currentPassword": "סיסמא נוכחית",
+  "emailAddress": "דוא\"ל",
+  "error": "שגיאה",
+  "forgotPassword": "שכחת סיסמא?",
+  "newPassword": "סיסמא חדשה",
+  "password": "סיסמא",
+  "passwordChanged": "סיסמתך שונתה בהצלחה",
+  "passwordResetSend": "הודעת דוא\"ל עם קישור לאיפוס הסיסמה נשלחה.",
+  "resetYourPassword": "איפוס סיסמא",
+  "setPassword": "עדכון סיסמא",
+  "signIn": "כניסה",
+  "signUp": "הרשמה לחשבון",
+  "signUpButton": "בצע רישום",
+  "updateYourPassword": "עדכון סיסמא"
+}

--- a/server/i18n/hr.json
+++ b/server/i18n/hr.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Promijeni lozinku",
+  "createAccount": "Kreiraj račun",
+  "currentPassword": "Trenutna lozinka",
+  "emailAddress": "Email Adresa",
+  "error": "Pogreška",
+  "forgotPassword": "Resetiraj lozinku",
+  "newPassword": "Nova lozinka",
+  "password": "Lozinka",
+  "passwordChanged": "Lozinka promijenjena",
+  "passwordResetSend": "E-mail s linkom za poništavanje lozinke je poslana.",
+  "resetYourPassword": "Resetiraj lozinku",
+  "setPassword": "Postavi lozinku",
+  "signIn": "Prijavi se",
+  "signUp": "Registriraj se",
+  "signUpButton": "Registrirajte se",
+  "updateYourPassword": "Ažuriraj lozinku"
+}

--- a/server/i18n/hu.json
+++ b/server/i18n/hu.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Jelszó változtatás",
+  "createAccount": "Fiók létrehozás",
+  "currentPassword": "Aktuális jelszó",
+  "emailAddress": "Email Cím",
+  "error": "Hiba",
+  "forgotPassword": "Jelszó Csere",
+  "newPassword": "Új Jelszó",
+  "password": "Jelszó",
+  "passwordChanged": "Jelszó megváltozott",
+  "passwordResetSend": "E-mail és jelszó linket elküldtük.",
+  "resetYourPassword": "Jelszó csere",
+  "setPassword": "Jelszó megadás",
+  "signIn": "Bejelentkezés",
+  "signUp": "Regisztráció",
+  "signUpButton": "Regisztráció",
+  "updateYourPassword": "Jelszó frissítése"
+}

--- a/server/i18n/it.json
+++ b/server/i18n/it.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Cambia password",
+  "createAccount": "Crea un Account",
+  "currentPassword": "Password corrente",
+  "emailAddress": "Indirizzo Email",
+  "error": "Errore",
+  "forgotPassword": "Hai dimenticato la password?",
+  "newPassword": "Nuova password",
+  "password": "Password",
+  "passwordChanged": "Password cambiata",
+  "passwordResetSend": "E-mail con il link per reimpostare la password è stata inviata.",
+  "resetYourPassword": "Reimposta la password",
+  "setPassword": "Imposta password",
+  "signIn": "Accedi",
+  "signUp": "Registrati",
+  "signUpButton": "Registrazione",
+  "updateYourPassword": "Aggiorna la password"
+}

--- a/server/i18n/my.json
+++ b/server/i18n/my.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "စကားဝှက်ပြောင်းရန်",
+  "createAccount": "အကောင့်အသစ်ဖွင့်ရန်",
+  "currentPassword": "လက်ရှိ စကားဝှက်",
+  "emailAddress": "အီးမေးလ်",
+  "error": "အမှား",
+  "forgotPassword": "စကားဝှက်မေ့သွားပါသလား။",
+  "newPassword": "စကားဝှက် အသစ်",
+  "password": "စကားဝှက်",
+  "passwordChanged": "စကားဝှက် ပြောင်းလိုက်ပြီးဖြစ်သည်",
+  "passwordResetSend": "စကားဝှက်ပြန်ညှိ link ကိုအတူအီးမေးလ်ကိုစလှေတျခဲ့သညျ။",
+  "resetYourPassword": "စကားဝှက်ပြောင်းရန်",
+  "setPassword": "စကားဝှက် ထားရန်",
+  "signIn": "အကောင့်ဝင်ရန်",
+  "signUp": "မှတ်ပုံတင်ရန်",
+  "signUpButton": "စာရင်း",
+  "updateYourPassword": "စကားဝှက် ပြောင်းရန်"
+}

--- a/server/i18n/nb.json
+++ b/server/i18n/nb.json
@@ -1,0 +1,17 @@
+{
+  "changePassword": "Endre Passord",
+  "createAccount": "Opprett Konto",
+  "currentPassword": "Eksisterende Passord",
+  "emailAddress": "Epost Adresse",
+  "forgotPassword": "Nullstill passord",
+  "newPassword": "Nytt Passord",
+  "password": "Passord",
+  "passwordChanged": "Passord endret",
+  "passwordResetSend": "Epost med lenke for å nullstile passord er sendt.",
+  "resetYourPassword": "Nullstill passord",
+  "setPassword": "Sett Passord",
+  "signIn": "Logg Inn",
+  "signUp": "Registrer",
+  "signUpButton": "Registrer",
+  "updateYourPassword": "Oppdater ditt passord"
+}

--- a/server/i18n/nl.json
+++ b/server/i18n/nl.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Wachtwoord wijzigen",
+  "createAccount": "Account aanmaken",
+  "currentPassword": "Huidig wachtwoord",
+  "emailAddress": "E-mailadres",
+  "error": "Fout",
+  "forgotPassword": "Wachtwoord herstellen",
+  "newPassword": "Nieuw wachtwoord",
+  "password": "Wachtwoord",
+  "passwordChanged": "Wachtwoord veranders",
+  "passwordResetSend": "E-mail met wachtwoord opnieuw verbinding is verzonden.",
+  "resetYourPassword": "Uw wachtwoord resetten",
+  "setPassword": "Wachtwoord instellen",
+  "signIn": "Inloggen",
+  "signUp": "Registreren",
+  "signUpButton": "Register",
+  "updateYourPassword": "Uw wachtwoord bijwerken"
+}

--- a/server/i18n/pl.json
+++ b/server/i18n/pl.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Zmień hasło",
+  "createAccount": "Utwórz konto",
+  "currentPassword": "Aktualne hasło",
+  "emailAddress": "Adres email",
+  "error": "Błąd",
+  "forgotPassword": "Zapomniałeś hasła?",
+  "newPassword": "Nowe hasło",
+  "password": "Hasło",
+  "passwordChanged": "Hasło zmienione",
+  "passwordResetSend": "E-mail z linkiem resetowania hasła została wysłana.",
+  "resetYourPassword": "Ustaw nowe hasło",
+  "setPassword": "Ustaw hasło",
+  "signIn": "Zaloguj się",
+  "signUp": "Zarejestruj się",
+  "signUpButton": "Rejestracja",
+  "updateYourPassword": "Zaktualizuj swoje hasło"
+}

--- a/server/i18n/pt.json
+++ b/server/i18n/pt.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Alterar palavra-passe",
+  "createAccount": "Criar uma conta",
+  "currentPassword": "Palavra-passe atual",
+  "emailAddress": "Endereço de email",
+  "error": "Erro",
+  "forgotPassword": "Repor palavra-passe",
+  "newPassword": "Nova palavra-passe",
+  "password": "Palavra-passe",
+  "passwordChanged": "Palavra-passe alterada",
+  "passwordResetSend": "Foi enviado um email com uma ligação para repor a palavra-passe.",
+  "resetYourPassword": "Repor a sua palavra-passe",
+  "setPassword": "Definir a palavra-passe",
+  "signIn": "Iniciar sessão",
+  "signUp": "Registar",
+  "signUpButton": "Registar",
+  "updateYourPassword": "Atualizar a sua palavra-passe"
+}

--- a/server/i18n/ro.json
+++ b/server/i18n/ro.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Schimbaţi parola",
+  "createAccount": "Creează un cont",
+  "currentPassword": "Parola curentă",
+  "emailAddress": "Adresa de email",
+  "error": "Eroare",
+  "forgotPassword": "Resetează parola",
+  "newPassword": "Noua Parolă",
+  "password": "Parola",
+  "passwordChanged": "Parola a fost schimbată",
+  "passwordResetSend": "E-mail-ul cu link-ul de resetare a parolei a fost trimis.",
+  "resetYourPassword": "Resetează parola",
+  "setPassword": "Seteaza parola",
+  "signIn": "Autentificare",
+  "signUp": "Înregistrează-te",
+  "signUpButton": "Înregistrează-te",
+  "updateYourPassword": "Actualizati parola"
+}

--- a/server/i18n/ru.json
+++ b/server/i18n/ru.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Сменить пароль",
+  "createAccount": "Создать аккаунт",
+  "currentPassword": "Текущий пароль",
+  "emailAddress": "Email",
+  "error": "Ошибка",
+  "forgotPassword": "Забыли пароль?",
+  "newPassword": "Новый пароль",
+  "password": "Пароль",
+  "passwordChanged": "Пароль изменен",
+  "passwordResetSend": "Email со сбросом пароля отправлен.",
+  "resetYourPassword": "Сбросить пароль",
+  "setPassword": "Установить пароль",
+  "signIn": "Войти",
+  "signUp": "Регистрация",
+  "signUpButton": "Зарегистрироваться",
+  "updateYourPassword": "Обновить пароль"
+}

--- a/server/i18n/sl.json
+++ b/server/i18n/sl.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Spremeni geslo",
+  "createAccount": "Nova registracija",
+  "currentPassword": "Trenutno geslo",
+  "emailAddress": "Email naslov",
+  "error": "Napaka",
+  "forgotPassword": "Pozabljeno geslo?",
+  "newPassword": "Novo geslo",
+  "password": "Geslo",
+  "passwordChanged": "Geslo spremenjeno",
+  "passwordResetSend": "E-pošta s povezavo za ponastavitev gesla so bila poslana.",
+  "resetYourPassword": "Ponastavi geslo",
+  "setPassword": "Nastavi geslo",
+  "signIn": "Prijava",
+  "signUp": "Registracija",
+  "signUpButton": "Register",
+  "updateYourPassword": "Spremeni geslo"
+}

--- a/server/i18n/sv.json
+++ b/server/i18n/sv.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Ändra lösenord",
+  "createAccount": "Skapa ett konto",
+  "currentPassword": "Nuvarande lösenord",
+  "emailAddress": "E-postadress",
+  "error": "Fel",
+  "forgotPassword": "Glömt din e-postadress?",
+  "newPassword": "Nytt lösenord",
+  "password": "Lösenord",
+  "passwordChanged": "Lösenordet har ändrats",
+  "passwordResetSend": "E-post med återställningslänk för ändring av lösenordet har skickats.",
+  "resetYourPassword": "Återställ ditt lösenord",
+  "setPassword": "Välj ett lösenord",
+  "signIn": "Logga in",
+  "signUp": "Skapa konto",
+  "signUpButton": "Registrera",
+  "updateYourPassword": "Uppdatera ditt lösenord"
+}

--- a/server/i18n/tr.json
+++ b/server/i18n/tr.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Şifre Değiştir",
+  "createAccount": "Hesap Oluştur",
+  "currentPassword": "Geçerli Şifre",
+  "emailAddress": "E-posta Adresi",
+  "error": "Hata",
+  "forgotPassword": "Şifremi Unuttum",
+  "newPassword": "Yeni Şifre",
+  "password": "Şifre",
+  "passwordChanged": "Şifre değiştirildi",
+  "passwordResetSend": "şifre sıfırlama bağlantısı içeren e-posta gönderildi.",
+  "resetYourPassword": "Şifrenizi sıfırlayın",
+  "setPassword": "Şifreyi Ayarla",
+  "signIn": "Giriş Yap",
+  "signUp": "Kaydol",
+  "signUpButton": "Kayıt",
+  "updateYourPassword": "Şifrenizi güncelleyin"
+}

--- a/server/i18n/translations.js
+++ b/server/i18n/translations.js
@@ -1,5 +1,51 @@
+import ar from "./ar.json";
+import bg from "./bg.json";
+import cs from "./cs.json";
+import de from "./de.json";
+import el from "./el.json";
 import en from "./en.json";
+import es from "./es.json";
+import fr from "./fr.json";
+import he from "./he.json";
+import hr from "./hr.json";
+import hu from "./hu.json";
+import it from "./it.json";
+import my from "./my.json";
+import nb from "./nb.json";
+import nl from "./nl.json";
+import pl from "./pl.json";
+import pt from "./pt.json";
+import ro from "./ro.json";
+import ru from "./ru.json";
+import sl from "./sl.json";
+import sv from "./sv.json";
+import tr from "./tr.json";
+import vi from "./vi.json";
+import zh from "./zh.json";
 
 export default {
-  en
+  ar,
+  bg,
+  cs,
+  de,
+  el,
+  en,
+  es,
+  fr,
+  he,
+  hr,
+  hu,
+  it,
+  my,
+  nb,
+  nl,
+  pl,
+  pt,
+  ro,
+  ru,
+  sl,
+  sv,
+  tr,
+  vi,
+  zh
 };

--- a/server/i18n/vi.json
+++ b/server/i18n/vi.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "Đổi mật khẩu",
+  "createAccount": "Tạo Tài khoản",
+  "currentPassword": "Mật khẩu hiện tại",
+  "emailAddress": "Địa chỉ Email",
+  "error": "lỗi",
+  "forgotPassword": "Quên mật khẩu?",
+  "newPassword": "Mật khẩu mới",
+  "password": "Mật khẩu",
+  "passwordChanged": "Mật khẩu đã thay đổi",
+  "passwordResetSend": "Gửi email với các liên kết thiết lập lại mật khẩu đã được gửi đi.",
+  "resetYourPassword": "Lấy lại mật khẩu",
+  "setPassword": "Đặt mật khẩu",
+  "signIn": "Đăng nhập",
+  "signUp": "Đăng ký",
+  "signUpButton": "Ghi danh",
+  "updateYourPassword": "Cập nhật mật khẩu"
+}

--- a/server/i18n/zh.json
+++ b/server/i18n/zh.json
@@ -1,0 +1,18 @@
+{
+  "changePassword": "修改密码",
+  "createAccount": "创建账户",
+  "currentPassword": "当前密码",
+  "emailAddress": "电子邮件地址",
+  "error": "错误",
+  "forgotPassword": "重置密码",
+  "newPassword": "新密码",
+  "password": "密码",
+  "passwordChanged": "密码已修改",
+  "passwordResetSend": "重置密码的邮件已经发送。",
+  "resetYourPassword": "重置您的密码",
+  "setPassword": "设置密码",
+  "signIn": "登录",
+  "signUp": "注册",
+  "signUpButton": "注册",
+  "updateYourPassword": "更新您的密码"
+}


### PR DESCRIPTION
Resolves #1 

## Changes
Adds translation files for all supported non-English languages.

## Testing
I generated the language JSON files using a script that pulled them from the existing API translations, so they should be as correct as those were.

It should be sufficient to run the app and go to http://localhost:4100/account/login?lng=es in a browser. Verify that you see the UI in Spanish.