### PR TITLE
chore: release v3.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v3.0.0-alpha.2
+
+## Features
+
+- feat: add non-English translations [#13](https://github.com/reactioncommerce/reaction-identity/pull/13)
+- feat: add remaining identity provider flows [#12](https://github.com/reactioncommerce/reaction-identity/pull/12)
+
+## Chores
+
+- chore: fixed links, text, and commands in readme [#9](https://github.com/reactioncommerce/reaction-identity/pull/9)
+- chore: add DCO and contributing info to readme [#7](https://github.com/reactioncommerce/reaction-identity/pull/7)
+
 # v3.0.0-alpha
 
 ## Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-identity",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.0.0-alpha",
+  "version": "3.0.0-alpha.2",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.0.0-alpha.2

## Features

- feat: add non-English translations [#13](https://github.com/reactioncommerce/reaction-identity/pull/13)
- feat: add remaining identity provider flows [#12](https://github.com/reactioncommerce/reaction-identity/pull/12)

## Chores

- chore: fixed links, text, and commands in readme [#9](https://github.com/reactioncommerce/reaction-identity/pull/9)
- chore: add DCO and contributing info to readme [#7](https://github.com/reactioncommerce/reaction-identity/pull/7)