### PR TITLE
release v3.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v3.0.0-beta
+
 This is the beta release of the Reaction Identity project that is designed to work with our new Reaction API.
 
 Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a beta release, and all projects in coordination for the official v3.0.0 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is the beta release of the Reaction Identity project that is designed to work with our new Reaction API.
 
-Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a beta release, and all projects in coordination for the official v3.0.0 release.
+*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
 
 ## Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v3.0.0-beta
+This is the beta release of the Reaction Identity project that is designed to work with our new Reaction API.
+
+Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a beta release, and all projects in coordination for the official v3.0.0 release.
+
+## Fix
+
+- fix: add missing onCreateUser [#9](https://github.com/reactioncommerce/reaction-identity/pull/14)
+
 # v3.0.0-alpha.2
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.0.0-alpha.2",
+  "version": "3.0.0-beta",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.0.0-beta

This is the beta release of the Reaction Identity project that is designed to work with our new Reaction API.

Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a beta release, and all projects in coordination for the official v3.0.0 release.

## Fix

- fix: add missing onCreateUser [#9](https://github.com/reactioncommerce/reaction-identity/pull/14)