### PR TITLE
release v3.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# v3.0.0-beta.2
+
+This is the second beta release of the Reaction Identity project that is designed to work with our new Reaction API.
+
+*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
+
+## Features
+
+- feat: update to Meteor 1.9 [21](https://github.com/reactioncommerce/reaction-identity/pull/21)
+
+## Refactors
+
+- refactor: remove hook which makes initial user "owner" [22](https://github.com/reactioncommerce/reaction-identity/pull/22)
+
+## Chores
+
+- chore: reconfigure docker-compose networks [23](https://github.com/reactioncommerce/reaction-identity/pull/23)
+
+## Docs
+
+- docs: update links to use trunk branch of docs [19](https://github.com/reactioncommerce/reaction-identity/pull/19)
+
 # v3.0.0-beta
 
 This is the beta release of the Reaction Identity project that is designed to work with our new Reaction API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-identity",
-  "version": "3.0.0-beta",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.0.0-beta",
+  "version": "3.0.0-beta.2",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.0.0-beta.2

This is the second beta release of the Reaction Identity project that is designed to work with our new Reaction API.

*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*

## Features

- feat: update to Meteor 1.9 [21](https://github.com/reactioncommerce/reaction-identity/pull/21)

## Refactors

- refactor: remove hook which makes initial user "owner" [22](https://github.com/reactioncommerce/reaction-identity/pull/22)

## Chores

- chore: reconfigure docker-compose networks [23](https://github.com/reactioncommerce/reaction-identity/pull/23)

## Docs

- docs: update links to use trunk branch of docs [19](https://github.com/reactioncommerce/reaction-identity/pull/19)