### PR TITLE
feat: release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v3.1.0
+
+This release of `reaction-identity` is designed to work with v3.x of the Reaction API.
+
+### Features
+
+- feat: update to Meteor 1.10.2 ([#31](http://github.com/reactioncommerce/reaction-identity/pull/31))
+
+### Chores
+
+- chore(deps): Bump acorn from 7.1.0 to 7.1.1 ([#30](http://github.com/reactioncommerce/reaction-identity/pull/30))
+
 # v3.0.0
 
 This is the v3.0.0 release of `reaction-identity`, designed to work with v3.0.0 of the Reaction API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   identity:
-    image: reactioncommerce/identity:3.0.0
+    image: reactioncommerce/identity:3.1.0
     env_file:
       - ./.env
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-identity",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -655,9 +655,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -3076,7 +3076,8 @@
       "dependencies": {
         "asn1.js": {
           "version": "4.10.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -3085,14 +3086,16 @@
         },
         "assert": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
           "requires": {
             "util": "0.10.3"
           },
           "dependencies": {
             "util": {
               "version": "0.10.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
               "requires": {
                 "inherits": "2.0.1"
               }
@@ -3101,19 +3104,23 @@
         },
         "base64-js": {
           "version": "1.3.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "bn.js": {
           "version": "4.11.8",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "brorand": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
             "buffer-xor": "^1.0.3",
             "cipher-base": "^1.0.0",
@@ -3125,7 +3132,8 @@
         },
         "browserify-cipher": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
           "requires": {
             "browserify-aes": "^1.0.4",
             "browserify-des": "^1.0.0",
@@ -3134,7 +3142,8 @@
         },
         "browserify-des": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
           "requires": {
             "cipher-base": "^1.0.1",
             "des.js": "^1.0.0",
@@ -3144,7 +3153,8 @@
         },
         "browserify-rsa": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "requires": {
             "bn.js": "^4.1.0",
             "randombytes": "^2.0.1"
@@ -3152,7 +3162,8 @@
         },
         "browserify-sign": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
           "requires": {
             "bn.js": "^4.1.1",
             "browserify-rsa": "^4.0.0",
@@ -3165,14 +3176,16 @@
         },
         "browserify-zlib": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
           "requires": {
             "pako": "~1.0.5"
           }
         },
         "buffer": {
           "version": "5.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -3180,15 +3193,18 @@
         },
         "buffer-xor": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "builtin-status-codes": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
         },
         "cipher-base": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -3196,22 +3212,26 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "requires": {
             "date-now": "^0.1.4"
           }
         },
         "constants-browserify": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "create-ecdh": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
           "requires": {
             "bn.js": "^4.1.0",
             "elliptic": "^6.0.0"
@@ -3219,7 +3239,8 @@
         },
         "create-hash": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "requires": {
             "cipher-base": "^1.0.1",
             "inherits": "^2.0.1",
@@ -3230,7 +3251,8 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
             "cipher-base": "^1.0.3",
             "create-hash": "^1.1.0",
@@ -3242,7 +3264,8 @@
         },
         "crypto-browserify": {
           "version": "3.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
           "requires": {
             "browserify-cipher": "^1.0.0",
             "browserify-sign": "^4.0.0",
@@ -3259,11 +3282,13 @@
         },
         "date-now": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
         "des.js": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
           "requires": {
             "inherits": "^2.0.1",
             "minimalistic-assert": "^1.0.0"
@@ -3271,7 +3296,8 @@
         },
         "diffie-hellman": {
           "version": "5.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
           "requires": {
             "bn.js": "^4.1.0",
             "miller-rabin": "^4.0.0",
@@ -3280,11 +3306,13 @@
         },
         "domain-browser": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
         },
         "elliptic": {
           "version": "6.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -3297,11 +3325,13 @@
         },
         "events": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
         },
         "evp_bytestokey": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "requires": {
             "md5.js": "^1.3.4",
             "safe-buffer": "^5.1.1"
@@ -3309,7 +3339,8 @@
         },
         "hash-base": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -3317,7 +3348,8 @@
         },
         "hash.js": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.1"
@@ -3325,13 +3357,15 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "hmac-drbg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -3340,23 +3374,28 @@
         },
         "https-browserify": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
         },
         "ieee754": {
           "version": "1.1.13",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "inherits": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "md5.js": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1",
@@ -3365,7 +3404,8 @@
         },
         "miller-rabin": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "requires": {
             "bn.js": "^4.0.0",
             "brorand": "^1.0.1"
@@ -3373,23 +3413,28 @@
         },
         "minimalistic-assert": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "os-browserify": {
           "version": "0.3.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
         },
         "pako": {
           "version": "1.0.10",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
         },
         "parse-asn1": {
           "version": "5.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
           "requires": {
             "asn1.js": "^4.0.0",
             "browserify-aes": "^1.0.0",
@@ -3401,11 +3446,13 @@
         },
         "path-browserify": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
         },
         "pbkdf2": {
           "version": "3.0.17",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
           "requires": {
             "create-hash": "^1.1.2",
             "create-hmac": "^1.1.4",
@@ -3416,15 +3463,18 @@
         },
         "process": {
           "version": "0.11.10",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "public-encrypt": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
           "requires": {
             "bn.js": "^4.1.0",
             "browserify-rsa": "^4.0.0",
@@ -3436,26 +3486,31 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "querystring": {
           "version": "0.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
         },
         "randombytes": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
           "requires": {
             "safe-buffer": "^5.1.0"
           }
         },
         "randomfill": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
           "requires": {
             "randombytes": "^2.0.5",
             "safe-buffer": "^5.1.0"
@@ -3463,7 +3518,8 @@
         },
         "readable-stream": {
           "version": "3.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -3472,13 +3528,15 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "ripemd160": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
@@ -3486,15 +3544,18 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "setimmediate": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
         },
         "sha.js": {
           "version": "2.4.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -3502,7 +3563,8 @@
         },
         "stream-browserify": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "^2.0.2"
@@ -3510,7 +3572,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -3523,13 +3586,15 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "bundled": true
+                  "resolved": false,
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 }
               }
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -3538,7 +3603,8 @@
         },
         "stream-http": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
           "requires": {
             "builtin-status-codes": "^3.0.0",
             "inherits": "^2.0.1",
@@ -3548,25 +3614,29 @@
         },
         "string_decoder": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "timers-browserify": {
           "version": "2.0.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
           "requires": {
             "setimmediate": "^1.0.4"
           }
         },
         "tty-browserify": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
         },
         "url": {
           "version": "0.11.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
           "requires": {
             "punycode": "1.3.2",
             "querystring": "0.2.0"
@@ -3574,34 +3644,40 @@
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             }
           }
         },
         "util": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
           "requires": {
             "inherits": "2.0.3"
           },
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vm-browserify": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
@@ -3643,9 +3719,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
       "version": "2.9.0",
@@ -3665,11 +3741,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "0.0.8"
       }
     },
     "moment": {
@@ -4234,9 +4310,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "strip-json-comments": {
           "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -655,9 +655,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -3719,9 +3719,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -3741,11 +3741,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "moment": {
@@ -4310,9 +4310,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "strip-json-comments": {
           "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.1.0

This release of `reaction-identity` is designed to work with v3.x of the Reaction API.

### Features

- feat: update to Meteor 1.10.2 ([#31](http://github.com/reactioncommerce/reaction-identity/pull/31))

### Chores

- chore(deps): Bump acorn from 7.1.0 to 7.1.1 ([#30](http://github.com/reactioncommerce/reaction-identity/pull/30))