### PR TITLE
fix: Include X-Forwarded-Proto header on Hydra GET requests

### DIFF
--- a/server/hydra.js
+++ b/server/hydra.js
@@ -25,7 +25,14 @@ if (MOCK_TLS_TERMINATION) {
  */
 const get = async (flow, challenge) => {
   try {
-    const res = await fetch(`${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}?${flow}_challenge=${challenge}`);
+    const res = await fetch(
+      `${HYDRA_ADMIN_URL}/oauth2/auth/requests/${flow}?${flow}_challenge=${challenge}`,
+      {
+        headers: {
+          ...mockTlsTermination
+        }
+      }
+    );
     if (res.status < 200 || res.status > 302) {
       const json = await res.json();
       Logger.error(`An error occurred while making GET ${flow}-${challenge} HTTP request to Hydra: `, json.error_description);


### PR DESCRIPTION
Adds the X-Forwarded-Proto to all GET requests to Hydras admin endpoint, as already exists for PUT requests.

### Background
When Hydra is run in production, it requires https connections. Except when run behind a load balancer that does TLS termination for example, in which case it will accept http requests from an allowed list of IP addresses that also contain the forwarded headed, as described [here](https://www.ory.sh/hydra/docs/production/). If hydra is run with `--dangerous-force-http` then this header is also not needed, but this is not advisable for prod, and breaks the SameSite+Secure cookies which chrome rejects.

Without the header, the request is rejected by Hydra. This PR adds the header to GET requests and is controlled the same way, by an env var flag.

Signed-off-by: Sam Kelleher <sam@samkelleher.com>