### PR TITLE
release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v3.2.0
+
+This release of `reaction-identity` is designed to work with v3.x of the Reaction API.
+
+### Fixes
+
+- fix: Include X-Forwarded-Proto header on Hydra GET requests ([#35](http://github.com/reactioncommerce/reaction-identity/pull/35))
+
+### Chores
+
+- chore(deps): Bump lodash from 4.17.15 to 4.17.19 ([#34](http://github.com/reactioncommerce/reaction-identity/pull/34))
+
 # v3.1.0
 
 This release of `reaction-identity` is designed to work with v3.x of the Reaction API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   identity:
-    image: reactioncommerce/identity:3.1.0
+    image: reactioncommerce/identity:3.2.0
     env_file:
       - ./.env
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-identity",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.2.0

This release of `reaction-identity` is designed to work with v3.x of the Reaction API.

### Fixes

- fix: Include X-Forwarded-Proto header on Hydra GET requests ([#35](http://github.com/reactioncommerce/reaction-identity/pull/35))

### Chores

- chore(deps): Bump lodash from 4.17.15 to 4.17.19 ([#34](http://github.com/reactioncommerce/reaction-identity/pull/34))