### PR TITLE
release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v3.3.0
+
+This release of `reaction-identity` is designed to work with v3.x of the Reaction API.
+
+### Chores
+
+- chore(deps): Bump bcrypt from 3.0.7 to 5.0.0 ([#37](https://github.com/reactioncommerce/reaction-identity/pull/37))
+- chore(deps): Bump node-fetch from 2.6.0 to 2.6.1 ([#41](https://github.com/reactioncommerce/reaction-identity/pull/41))
+- chore(deps): Bump bl from 2.2.0 to 2.2.1 ([#40](https://github.com/reactioncommerce/reaction-identity/pull/40))
+- chore: update to Meteor 1.11.1 ([#42](https://github.com/reactioncommerce/reaction-identity/pull/42))
+
+## Contributors
+
+Thanks to @loan-laux for contributing to this release! 🎉
+
 # v3.2.0
 
 This release of `reaction-identity` is designed to work with v3.x of the Reaction API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   identity:
-    image: reactioncommerce/identity:3.2.0
+    image: reactioncommerce/identity:3.3.0
     env_file:
       - ./.env
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-identity",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.3.0

This release of `reaction-identity` is designed to work with v3.x of the Reaction API.

### Chores

- chore(deps): Bump bcrypt from 3.0.7 to 5.0.0 ([#37](https://github.com/reactioncommerce/reaction-identity/pull/37))
- chore(deps): Bump node-fetch from 2.6.0 to 2.6.1 ([#41](https://github.com/reactioncommerce/reaction-identity/pull/41))
- chore(deps): Bump bl from 2.2.0 to 2.2.1 ([#40](https://github.com/reactioncommerce/reaction-identity/pull/40))
- chore: update to Meteor 1.11.1 ([#42](https://github.com/reactioncommerce/reaction-identity/pull/42))

## Contributors

Thanks to @loan-laux for contributing to this release! 🎉