### PR TITLE
Release v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v3.3.1
+
+Reaction v3.3.1 adds patch features or bug fixes and contains no breaking changes since v3.3.0.
+
+## Chore
+
+ - chore(deps): Bump ini from 1.3.5 to 1.3.8 ([#44](https://github.com/reactioncommerce/reaction-identity/pull/44))
+
 # v3.3.0
 
 This release of `reaction-identity` is designed to work with v3.x of the Reaction API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   identity:
-    image: reactioncommerce/identity:3.3.0
+    image: reactioncommerce/identity:3.3.1
     env_file:
       - ./.env
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaction-identity",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reaction-identity",
   "description": "A server providing identity services for Reaction Commerce using Meteor's Accounts packages",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "homepage": "https://github.com/reactioncommerce/reaction-identity",
   "url": "https://github.com/reactioncommerce/reaction-identity",
   "repository": {


### PR DESCRIPTION
# v3.3.1

Reaction v3.3.1 adds patch features or bug fixes and contains no breaking changes since v3.3.0.

## Chore

 - chore(deps): Bump ini from 1.3.5 to 1.3.8 ([#44](https://github.com/reactioncommerce/reaction-identity/pull/44))

